### PR TITLE
Composer 2.0 functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=7.2",
     "contao/core-bundle": "~3.5 || ~4.4",
-    "contao-community-alliance/composer-plugin":"~2.4 || ~3.0",
+    "contao-community-alliance/composer-plugin":"~2.4 || ^3.0",
     "contao/news-bundle": "^4.4",
     "contao/newsletter-bundle": "^4.4"
   },


### PR DESCRIPTION
Change version constraint of composer-plugin from ~3.0 to ^3.0 to allow update to 3.1. In version 3.1 Composer 2.0 can be used.